### PR TITLE
Feat: Run OpenDistro without Security plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ For elasticsearch change into the `elastic` folder. Then
 * Upload the elastic package. Either
   * with minio: `dcosdev up`  (environment variables `MINIO_HOST`, `MINIO_ACCESS_KEY` and `MINIO_SECRET_KEY` must be set)
   * with S3: `dcosdev release 0 <bucket-name>`.
-* Add repo-file to your clusters package repositories (e.g. for S3: `dcos package repo add opendistro--index=0 https://<bucket-name>.s3.amazonaws.com/packages/opendistro/0.1.0-1.2.0/opendistro-repo.json`)
+* Add repo-file to your clusters package repositories (e.g. for S3: `dcos package repo add opendistro --index=0 https://<bucket-name>.s3.amazonaws.com/packages/opendistro/0.1.0-1.2.0/opendistro-repo.json`)
 * Prepare security config (see [opendistro documentation](https://opendistro.github.io/for-elasticsearch-docs/docs/security-configuration/yaml/)), place it into a folder called `securityconfig`, zip that folder and upload it to a place where it is downloadable via HTTP from inside the cluster (e.g. an S3 bucket). As a starting-point you can use the example from the [opendistro-security github-repo](https://github.com/opendistro-for-elasticsearch/security/tree/master/securityconfig)
 * Create serviceaccount for the framework to use (for TLS certificates to all elastic nodes)
 * Prepare `options.json` (see example in `example/options-elastic.json`)
@@ -35,7 +35,7 @@ For kibana change into the `kibana` folder. Then
 * Upload the kibana package. Either
   * with minio: `dcosdev up`  (environment variables `MINIO_HOST`, `MINIO_ACCESS_KEY` and `MINIO_SECRET_KEY` must be set)
   * with S3: `dcosdev release 0 <bucket-name>`.
-* Add repo-file to your clusters package repositories (e.g. for S3: `dcos package repo add opendistro--index=0 https://<bucket-name>.s3.amazonaws.com/packages/opendistro-kibana/0.1.0-1.2.0/opendistro-kibana-repo.json`)
+* Add repo-file to your clusters package repositories (e.g. for S3: `dcos package repo add opendistro --index=0 https://<bucket-name>.s3.amazonaws.com/packages/opendistro-kibana/0.1.0-1.2.0/opendistro-kibana-repo.json`)
 * Create secrets with username and password to use for authentication against elasticsearch.
 * Prepare `options.json` (see example in `example/options-kibana.json`)
 * Install package with your `options.json`

--- a/elastic/files/elasticsearch.yml
+++ b/elastic/files/elasticsearch.yml
@@ -68,6 +68,10 @@ opendistro_security.ssl.http.truststore_filepath: {{MESOS_SANDBOX}}/server.trust
 opendistro_security.ssl.http.truststore_password: notsecure
 {{/SECURITY_ENABLED}}
 
+{{^SECURITY_ENABLED}}
+opendistro_security.disabled: true
+{{/SECURITY_ENABLED}}
+
 {{#NODE_STORE_ALLOW_MMAP}}
 # https://www.elastic.co/guide/en/elasticsearch/reference/7.3/index-modules-store.html
 node.store.allow_mmap: {{NODE_STORE_ALLOW_MMAP}}

--- a/elastic/files/securityadmin.sh
+++ b/elastic/files/securityadmin.sh
@@ -12,7 +12,7 @@ if [ -n ${SECURITY_CONFIG_URL} ]; then
     FILENAME=$(basename $SECURITY_CONFIG_URL)
 
     rm -rf securityconfig*
-    wget ${SECURITY_CONFIG_URL}
+    curl -o securityconfig.zip ${SECURITY_CONFIG_URL}
     unzip $FILENAME
     rm $FILENAME
 

--- a/elastic/universe/config.json
+++ b/elastic/universe/config.json
@@ -842,6 +842,11 @@
           "type": "boolean",
           "default": true
         },
+        "xpack_security_enabled": {
+          "description": "Set to false if xpack_security isn't required",
+          "type": "boolean",
+          "default": true
+        },
         "action_destructive_requires_name": {
           "description": "In order to disable allowing to delete indices via wildcards or _all, set it as true.",
           "type": "boolean",

--- a/elastic/universe/config.json
+++ b/elastic/universe/config.json
@@ -842,11 +842,6 @@
           "type": "boolean",
           "default": true
         },
-        "xpack_security_enabled": {
-          "description": "Set to false if xpack_security isn't required",
-          "type": "boolean",
-          "default": true
-        },
         "action_destructive_requires_name": {
           "description": "In order to disable allowing to delete indices via wildcards or _all, set it as true.",
           "type": "boolean",

--- a/example/options-elastic.json
+++ b/example/options-elastic.json
@@ -13,8 +13,7 @@
         "health_user": "CHANGEME",
         "health_user_password": "CHANGEME",
         "plugins": "",
-        "opendistro_security_config_zip": "{{s3_base_path}}/securityconfig.zip",
-        "xpack_security_enabled": true
+        "opendistro_security_config_zip": "{{s3_base_path}}/securityconfig.zip"
     },
     "coordinator_nodes": {
         "count": 1,

--- a/example/options-elastic.json
+++ b/example/options-elastic.json
@@ -10,10 +10,11 @@
         "mem": 2048
     },
     "elasticsearch": {
-        "health_user": "monitor",
+        "health_user": "CHANGEME",
         "health_user_password": "CHANGEME",
         "plugins": "",
-        "opendistro_security_config_zip": "{{s3_base_path}}/securityconfig.zip"
+        "opendistro_security_config_zip": "{{s3_base_path}}/securityconfig.zip",
+        "xpack_security_enabled": true
     },
     "coordinator_nodes": {
         "count": 1,

--- a/example/options-kibana.json
+++ b/example/options-kibana.json
@@ -2,7 +2,8 @@
     "kibana": {
         "elastic_url": "https://coordinator.opendistro.l4lb.thisdcos.directory:9200",
         "username_secret": "/opendistro-kibana/username",
-        "password_secret": "/opendistro-kibana/password"
+        "password_secret": "/opendistro-kibana/password",
+        "opendistro_security_enabled": false
     },
     "service": {
         "name": "kibana-opendistro",

--- a/kibana/files/kibana_setup.sh
+++ b/kibana/files/kibana_setup.sh
@@ -30,5 +30,11 @@ EOF
 if [ "$KIBANA_ELASTICSEARCH_TLS" = true ]; then
 	echo -e "\nelasticsearch.ssl.certificateAuthorities: $MESOS_SANDBOX/.ssl/ca-bundle.crt\n" >> $KIBANA_YAML
 fi
-$MESOS_SANDBOX/kibana-$ELASTIC_VERSION-linux-x86_64/bin/kibana-plugin install file://$MESOS_SANDBOX/opendistro_security_kibana_plugin-${OPENDISTRO_SECURITY_VERSION}.zip
+
+if [ "$OPENDISTRO_SECURITY_ENABLED" = true ] then 
+	$MESOS_SANDBOX/kibana-$ELASTIC_VERSION-linux-x86_64/bin/kibana-plugin install file://$MESOS_SANDBOX/opendistro_security_kibana_plugin-${OPENDISTRO_SECURITY_VERSION}.zip
+else
+	sed -i '/^opendistro_security\.multitenancy\.enabled.*$/s/^/#/' $KIBANA_YAML
+fi  
+
 exec $MESOS_SANDBOX/kibana-$ELASTIC_VERSION-linux-x86_64/bin/kibana

--- a/kibana/universe/config.json
+++ b/kibana/universe/config.json
@@ -114,6 +114,11 @@
         "password_secret": {
           "description": "Path to secret containg password to use when authenticating to elastic",
           "type": "string"
+        },
+        "opendistro_security_enabled": {
+          "description": "OpenDistro security plugin is excluded if not enabled",
+          "type": "boolean",
+          "default": true
         }
       },
       "required": [

--- a/kibana/universe/marathon.json.mustache
+++ b/kibana/universe/marathon.json.mustache
@@ -51,7 +51,7 @@
       "ipProtocol": "IPv4",
       "maxConsecutiveFailures": 4,
       "path": "/api/status",
-      "port": 5601,
+      "portIndex": 0,
       "protocol": "MESOS_HTTP",
       "timeoutSeconds": 30
     }

--- a/kibana/universe/marathon.json.mustache
+++ b/kibana/universe/marathon.json.mustache
@@ -35,7 +35,8 @@
     "KIBANA_ELASTICSEARCH_TLS": "true",
     "KIBANA_PASSWORD": {"secret": "kibana-password"},
     "KIBANA_USER": {"secret": "kibana-username"},
-    "CUSTOM_YAML_BLOCK_BASE64": "{{kibana.custom_kibana_yml}}"
+    "CUSTOM_YAML_BLOCK_BASE64": "{{kibana.custom_kibana_yml}}",
+    "OPENDISTRO_SECURITY_ENABLED": "{{kibana.opendistro_security_enabled}}"
   },
   "fetch": [
     { "uri": "{{resource.assets.uris.kibana}}", "executable": false, "extract": true, "cache": true }, 
@@ -49,8 +50,8 @@
       "intervalSeconds": 30,
       "ipProtocol": "IPv4",
       "maxConsecutiveFailures": 4,
-      "path": "/status",
-      "portIndex": 0,
+      "path": "/api/status",
+      "port": 5601,
       "protocol": "MESOS_HTTP",
       "timeoutSeconds": 30
     }


### PR DESCRIPTION
1. Updated `elasticsearch.yml` to disable opendistro security.
2. curl replaces wget in `securityadmin.sh` which runs in `config-*` pod.
3. Added another key in `config.json`; this way user has the ability to disable `xpack-security`.
4. `kibana_setup.sh` earlier required OpenDistro Security plugin. Now one has the choice to disable security.
5. Fixed few typos in README.md